### PR TITLE
Unconditional connection retries

### DIFF
--- a/octoprint_portlister/__init__.py
+++ b/octoprint_portlister/__init__.py
@@ -70,13 +70,13 @@ class PortListerPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.AssetPlu
 		except:
 			self._logger.error("Exception in do_auto_connect %s", get_exception_string())
 
-    def check_connect_status(self, port, *args, **kwargs):
-        self._logger.info("check_connect_status")
+	def check_connect_status(self, port, *args, **kwargs):
+		self._logger.info("check_connect_status")
 
-        if self._printer.is_operational() == False:
-            self._logger.info("printer is not operational")
-            self._printer.disconnect()
-            Timer(self._settings.get(["autoconnect_delay"]), self.do_auto_connect, [port]).start()
+		if self._printer.is_operational() == False:
+                   self._logger.info("printer is not operational")
+                   self._printer.disconnect()
+                   Timer(self._settings.get(["autoconnect_delay"]), self.do_auto_connect, [port]).start()
 
 	def get_settings_defaults(self, *args, **kwargs):
 		return dict(autoconnect_delay=20)

--- a/octoprint_portlister/__init__.py
+++ b/octoprint_portlister/__init__.py
@@ -57,11 +57,16 @@ class PortListerPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.AssetPlu
 		try:
 			self._logger.info("do_auto_connect")
 			(autoport, baudrate) = self._settings.global_get(["serial", "port"]), self._settings.global_get_int(["serial", "baudrate"])
+			if not baudrate:
+ 				autobaudrate = "AUTO"
+ 				baudrate = 0
+ 			else:
+ 				autobaudrate = baudrate
 			if autoport == "AUTO" or os.path.realpath(autoport) == os.path.realpath(port):
 				self._logger.info("realpath match")
 				printer_profile = self._printer_profile_manager.get_default()
 				profile = printer_profile["id"] if "id" in printer_profile else "_default"
-				self._logger.info("Attempting to connect to %s at %d with profile %s" % (autoport, baudrate, repr(profile)))
+				self._logger.info("Attempting to connect to %s at %d with profile %s" % (autoport, autobaudrate, repr(profile)))
 				self._printer.connect(port=autoport, baudrate=baudrate, profile=profile)
 				Timer(self._settings.get(["autoconnect_delay"]), self.check_connect_status, [port]).start()
 			else:
@@ -76,10 +81,11 @@ class PortListerPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.AssetPlu
 		if self._printer.is_operational() == False:
                    self._logger.info("printer is not operational")
                    self._printer.disconnect()
-                   Timer(self._settings.get(["autoconnect_delay"]), self.do_auto_connect, [port]).start()
+		   self.do_auto_connect([port])
+                   #Timer(self._settings.get(["autoconnect_delay"]), self.do_auto_connect, [port]).start()
 
 	def get_settings_defaults(self, *args, **kwargs):
-		return dict(autoconnect_delay=30)
+		return dict(autoconnect_delay=20)
 
 	def get_assets(self, *args, **kwargs):
 		return dict(js=["js/portlister.js"])

--- a/octoprint_portlister/__init__.py
+++ b/octoprint_portlister/__init__.py
@@ -79,7 +79,7 @@ class PortListerPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.AssetPlu
                    Timer(self._settings.get(["autoconnect_delay"]), self.do_auto_connect, [port]).start()
 
 	def get_settings_defaults(self, *args, **kwargs):
-		return dict(autoconnect_delay=20)
+		return dict(autoconnect_delay=30)
 
 	def get_assets(self, *args, **kwargs):
 		return dict(js=["js/portlister.js"])
@@ -92,12 +92,12 @@ class PortListerPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.AssetPlu
 
 				# use github release method of version check
 				type="github_release",
-				user="markwal",
+				user="synman",
 				repo="OctoPrint-PortLister",
 				current=self._plugin_version,
 
 				# update method: pip
-				pip="https://github.com/markwal/OctoPrint-PortLister/archive/{target_version}.zip"
+				pip="https://github.com/synman/OctoPrint-PortLister/archive/{target_version}.zip"
 			)
 		)
 

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@
 plugin_identifier = "portlister"
 plugin_package = "octoprint_portlister"
 plugin_name = "OctoPrint-PortLister"
-plugin_version = "0.1.5"
+plugin_version = "0.1.6"
 plugin_description = """PortLister notices when printers get turned on and tells the list of ports to refresh"""
 plugin_author = "Mark Walker"
 plugin_author_email = "markwal@hotmail.com"
-plugin_url = "https://github.com/markwal/OctoPrint-PortLister"
+plugin_url = "https://github.com/synman/OctoPrint-PortLister"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 plugin_identifier = "portlister"
 plugin_package = "octoprint_portlister"
 plugin_name = "OctoPrint-PortLister"
-plugin_version = "0.1.6"
+plugin_version = "0.2.0"
 plugin_description = """PortLister notices when printers get turned on and tells the list of ports to refresh"""
 plugin_author = "Mark Walker"
 plugin_author_email = "markwal@hotmail.com"


### PR DESCRIPTION
Since it appears 50% of the time OctoPrint fails / hangs when first connecting I cooked up simple retry logic in your cool little plugin.

This retry logic is unconditional at present and verified on my end as fully functional. 

Perhaps it can be config / flag driven.  I really don't see the need myself but figured I'd share this little addition with you to do with as you please.